### PR TITLE
Add auto color, disable on gauntlet levels/weekly demons, color the loading circle as well

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,32 +3,65 @@
 
 using namespace geode::prelude;
 
-ccColor3B diffToColor(int diff) {
-	switch(diff) {
-		default: return {0, 102, 255};
-		case 0: return { 122, 122, 122 };
-		case 1: return { 4, 0, 255 };
-		case 2: return { 0, 180, 0 };
-		case 3: return { 255, 196, 0 };
-		case 4: return { 255, 115, 0 };
-		case 5: return { 255, 0, 234 };
-		case 6: return { 204, 0, 255 };
-		case 7: return { 223, 0, 223 };
-		case 8:
-		case 9:
-		return { 255, 0, 0 };
-		case 10: return { 175, 0, 0 };
-	}
+std::unordered_map<int, ccColor3B> DIFFICULTY_COLORS = {
+	{-1, {200, 200, 100}}, // Auto
+	{0,  {122, 122, 122}}, // NA
+	{1,  {  4,   0, 255}}, // Easy
+	{2,  {  0, 180,   0}}, // Medium
+	{3,  {255, 196,   0}}, // Hard
+	{4,  {255, 115,   0}}, // Harder
+	{5,  {255,   0, 234}}, // Insane
+	{6,  {204,   0, 255}}, // Easy Demon
+	{7,  {223,   0, 223}}, // Medium Demon
+	{8,  {223,   0, 223}}, // Hard Demon
+	{9,  {255,   0,   0}}, // Insane Demon
+	{10, {175,   0,   0}}  // Extreme Demon
+};
+// default difficulty color is {0, 102, 255}
+
+ccColor3B levelToColor(GJGameLevel *level) {
+	// if the level is not a demon, this is in [-1, 5] 
+	// (-1 is auto, 0 is NA, not the other way around for some reason)
+	// if the level is a demon, this is in [1, 5]
+	int average_difficulty = level->getAverageDifficulty();
+
+	// this is 0 if the level is not a demon, and 1 otherwise
+	int is_demon = level->m_demon.value();
+
+ 	// combine the two [-1, 5] and [1, 5] ranges to one [-1, 10] range
+	// if not demon: [-1, 5] + 5*0 = [-1,  5]
+	// if demon:     [ 1, 5] + 5*1 = [ 6, 10]
+	return DIFFICULTY_COLORS[average_difficulty + 5*is_demon];
 }
 
 class $modify(LevelInfoLayer) {
-	bool init(GJGameLevel* level, bool isGauntlet) {
-		if(!LevelInfoLayer::init(level, isGauntlet))
-			return false;
+	bool init(GJGameLevel* level, bool p1) {
+		if(!LevelInfoLayer::init(level, p1)) return false;
+		// gauntlet levels and the weekly demon have a dark bg rather than the default one, so let them keep it
+		if (level->m_gauntletLevel || level->m_gauntletLevel2) return true;
+		if (level->m_dailyID.value() && level->m_demon.value()) return true;
+
 		CCSprite* m_background = (CCSprite*)(this->getChildByID("background"));
-		auto color = diffToColor(level->getAverageDifficulty() + (level->m_demon.value() * 5));
-		log::info("{}", color);
+		ccColor3B color = levelToColor(level);
 		m_background->setColor(color);
+
 		return true;
+	}
+
+	void onPlay(CCObject *sender) {
+		LevelInfoLayer::onPlay(sender);
+		// gauntlet levels and the weekly demon have a dark bg rather than the default one, so let them keep it
+		if (m_level->m_gauntletLevel || m_level->m_gauntletLevel2) return;
+		if (m_level->m_dailyID.value() && m_level->m_demon.value()) return;
+
+		CCMenuItemSpriteExtra *playBtn = dynamic_cast<CCMenuItemSpriteExtra*>(m_playBtnMenu->getChildByID("play-button"));
+		CCSprite *playBtnSpr = dynamic_cast<CCSprite*>(playBtn->getChildren()->objectAtIndex(0));
+		
+		ccColor3B color = levelToColor(m_level);
+		ccColor3B darker_color = { GLubyte(color.r/2), GLubyte(color.g/2), GLubyte(color.b/2) };
+
+		dynamic_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(0))->setColor(darker_color);
+		dynamic_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(1))->setColor(darker_color);
+		dynamic_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(2))->setColor(color);
 	}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,9 +37,6 @@ ccColor3B levelToColor(GJGameLevel *level) {
 class $modify(LevelInfoLayer) {
 	bool init(GJGameLevel* level, bool p1) {
 		if(!LevelInfoLayer::init(level, p1)) return false;
-		// gauntlet levels and the weekly demon have a dark bg rather than the default one, so let them keep it
-		if (level->m_gauntletLevel || level->m_gauntletLevel2) return true;
-		if (level->m_dailyID.value() && level->m_demon.value()) return true;
 
 		CCSprite* m_background = (CCSprite*)(this->getChildByID("background"));
 		ccColor3B color = levelToColor(level);
@@ -50,9 +47,6 @@ class $modify(LevelInfoLayer) {
 
 	void onPlay(CCObject *sender) {
 		LevelInfoLayer::onPlay(sender);
-		// gauntlet levels and the weekly demon have a dark bg rather than the default one, so let them keep it
-		if (m_level->m_gauntletLevel || m_level->m_gauntletLevel2) return;
-		if (m_level->m_dailyID.value() && m_level->m_demon.value()) return;
 
 		CCMenuItemSpriteExtra *playBtn = dynamic_cast<CCMenuItemSpriteExtra*>(m_playBtnMenu->getChildByID("play-button"));
 		CCSprite *playBtnSpr = dynamic_cast<CCSprite*>(playBtn->getChildren()->objectAtIndex(0));
@@ -60,8 +54,8 @@ class $modify(LevelInfoLayer) {
 		ccColor3B color = levelToColor(m_level);
 		ccColor3B darker_color = { GLubyte(color.r/2), GLubyte(color.g/2), GLubyte(color.b/2) };
 
-		dynamic_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(0))->setColor(darker_color);
-		dynamic_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(1))->setColor(darker_color);
-		dynamic_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(2))->setColor(color);
+		static_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(0))->setColor(darker_color);
+		static_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(1))->setColor(darker_color);
+		static_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(2))->setColor(color);
 	}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,33 +4,23 @@
 using namespace geode::prelude;
 
 std::unordered_map<int, ccColor3B> DIFFICULTY_COLORS = {
-	{-1, {200, 200, 100}}, // Auto
-	{0,  {122, 122, 122}}, // NA
-	{1,  {  4,   0, 255}}, // Easy
-	{2,  {  0, 180,   0}}, // Medium
-	{3,  {255, 196,   0}}, // Hard
-	{4,  {255, 115,   0}}, // Harder
-	{5,  {255,   0, 234}}, // Insane
-	{6,  {204,   0, 255}}, // Easy Demon
-	{7,  {223,   0, 223}}, // Medium Demon
-	{8,  {223,   0, 223}}, // Hard Demon
-	{9,  {255,   0,   0}}, // Insane Demon
-	{10, {175,   0,   0}}  // Extreme Demon
+	{-1, {200, 200, 100}},
+	{0,  {122, 122, 122}},
+	{1,  {  4,   0, 255}},
+	{2,  {  0, 180,   0}},
+	{3,  {255, 196,   0}},
+	{4,  {255, 115,   0}},
+	{5,  {255,   0, 234}},
+	{6,  {204,   0, 255}},
+	{7,  {223,   0, 223}},
+	{8,  {223,   0, 223}},
+	{9,  {255,   0,   0}},
+	{10, {175,   0,   0}}
 };
-// default difficulty color is {0, 102, 255}
 
 ccColor3B levelToColor(GJGameLevel *level) {
-	// if the level is not a demon, this is in [-1, 5] 
-	// (-1 is auto, 0 is NA, not the other way around for some reason)
-	// if the level is a demon, this is in [1, 5]
 	int average_difficulty = level->getAverageDifficulty();
-
-	// this is 0 if the level is not a demon, and 1 otherwise
 	int is_demon = level->m_demon.value();
-
- 	// combine the two [-1, 5] and [1, 5] ranges to one [-1, 10] range
-	// if not demon: [-1, 5] + 5*0 = [-1,  5]
-	// if demon:     [ 1, 5] + 5*1 = [ 6, 10]
 	return DIFFICULTY_COLORS[average_difficulty + 5*is_demon];
 }
 
@@ -48,14 +38,16 @@ class $modify(LevelInfoLayer) {
 	void onPlay(CCObject *sender) {
 		LevelInfoLayer::onPlay(sender);
 
-		CCMenuItemSpriteExtra *playBtn = dynamic_cast<CCMenuItemSpriteExtra*>(m_playBtnMenu->getChildByID("play-button"));
-		CCSprite *playBtnSpr = dynamic_cast<CCSprite*>(playBtn->getChildren()->objectAtIndex(0));
+		CCMenuItemSpriteExtra *playBtn = static_cast<CCMenuItemSpriteExtra*> (m_playBtnMenu->getChildByID("play-button"));
+		CCSprite *playBtnSpr = getChild<CCSprite>(playBtn, 0);
 		
 		ccColor3B color = levelToColor(m_level);
 		ccColor3B darker_color = { GLubyte(color.r/2), GLubyte(color.g/2), GLubyte(color.b/2) };
-
-		static_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(0))->setColor(darker_color);
-		static_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(1))->setColor(darker_color);
-		static_cast<CCSprite*>(playBtnSpr->getChildren()->objectAtIndex(2))->setColor(color);
+		
+		if (playBtnSpr->getChildrenCount()) {
+			getChildOfType<CCSprite>(playBtnSpr, 0)->setColor(darker_color);
+			getChildOfType<CCSprite>(playBtnSpr, 1)->setColor(darker_color);
+			getChildOfType<CCSprite>(playBtnSpr, 2)->setColor(color);
+		}
 	}
 };


### PR DESCRIPTION
Added a color for auto levels (the auto average difficulty is -1 for some reason).

I disabled the mod on gauntlets/weeklies since those already use a non-default color, so I'd like to respect that; you can revert that if you think they should be changed too.

I also color the loading circle that appears around the play button since 2.2.